### PR TITLE
E2E: Default to master branch for rancher/telemtry

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ env:
   REPOSITORY: ${{ github.repository }}
   BRANCH: ${{ github.ref_name }}
   TELEMETRY_REPO: https://github.com/rancher/telemetry
-  TELEMETRY_BRANCH: ${{ vars.TELEMETRY_BRANCH || 'release' }}
+  TELEMETRY_BRANCH: ${{ vars.TELEMETRY_BRANCH || 'master' }}
 
 jobs:
   single-cluster:

--- a/src/influx.go
+++ b/src/influx.go
@@ -39,11 +39,11 @@ func newInflux(url, db, user, pass string) *Influx {
 func (i *Influx) Check(retry int) bool {
 	respTime, _, err := i.client.Ping(i.timeout)
 	if err != nil {
-		connected := i.Connect()
+		connected := i.Init()
 		for index := 1; index <= retry && !connected; index++ {
 			log.Warn("Influx disconnected. Reconnecting ", index+1, " of ", retry, "...")
 			time.Sleep(time.Duration(1) * time.Second)
-			connected = i.Connect()
+			connected = i.Init()
 			if connected {
 				respTime, _, err = i.client.Ping(i.timeout)
 			}


### PR DESCRIPTION
Change the branch to be used for testing of rancher/telemetry to `master`.