### PR TITLE
Fix drone configuration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,9 +19,8 @@ steps:
     custom_dns: 1.1.1.1
     dockerfile: Dockerfile
     repo: rancherlabs/rancher-telemetry-stats
-    tag: ${DRONE_TAG}
     build_args:
-      - version=${DRONE_TAG}
+      - version=master
     dry_run: true
   when:
     event:


### PR DESCRIPTION
Remove `DRONE_TAG` in first step of pipeline.

> Provides the tag for the current running build. This value is **only populated for tag events and promotion events** that are derived from tags.

`DRONE_TAG` also isn't used in the first step of rancher/telemetry.